### PR TITLE
Update chat_completions_ext.ts to fix the error in #19

### DIFF
--- a/src/lib/chat_completions_ext.ts
+++ b/src/lib/chat_completions_ext.ts
@@ -1,5 +1,5 @@
 // Manually curated models for streaming chat completions.
-import { ChatCompletion } from 'groq-sdk/resources/chat'
+import { ChatCompletion } from 'groq-sdk/resources/chat/index'
 
 export interface ChatCompletionChunk {
   id: string;


### PR DESCRIPTION
Particularly, this fixes the error
```
node_modules/groq-sdk/lib/chat_completions_ext.d.ts:1:32 - error TS2307: Cannot find module 'groq-sdk/resources/chat' or its corresponding type declarations.

1 import { ChatCompletion } from 'groq-sdk/resources/chat';
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~
```

FYI, I found the fix by checking another file (`streaming.d.ts`) in the same directory, which does not trigger the TS compilation error. (It uses `import { ReadableStream, type Response } from 'groq-sdk/_shims/index';`, note the final **index**.)